### PR TITLE
Skriver om aktiverHendelserJob til å bruke meldestatus

### DIFF
--- a/mediator/src/main/kotlin/no/nav/dagpenger/rapportering/personregister/mediator/ApplicationBuilder.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/rapportering/personregister/mediator/ApplicationBuilder.kt
@@ -231,7 +231,7 @@ internal class ApplicationBuilder(
                             aktiverHendelserJob,
                             personRepository,
                             personMediator,
-                            meldepliktMediator,
+                            meldestatusMediator,
                             meldepliktConnector,
                         )
                         personstatusApi(personMediator, synkroniserPersonMetrikker, personService)
@@ -261,7 +261,7 @@ internal class ApplicationBuilder(
     override fun onStartup(rapidsConnection: RapidsConnection) {
         runMigration()
         databaseMetrikker.startRapporteringJobb(personRepository)
-        aktiverHendelserJob.start(personRepository, personMediator, meldepliktMediator, meldepliktConnector)
+        aktiverHendelserJob.start(personRepository, personMediator, meldestatusMediator, meldepliktConnector)
         resendPaaVegneAvJob.start(personRepository, personService)
         meldestatusJob.start(personRepository, tempPersonRepository, meldepliktConnector, meldestatusMediator)
     }

--- a/mediator/src/main/kotlin/no/nav/dagpenger/rapportering/personregister/mediator/api/InternalApi.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/rapportering/personregister/mediator/api/InternalApi.kt
@@ -8,6 +8,7 @@ import io.ktor.server.routing.get
 import io.ktor.server.routing.routing
 import io.micrometer.prometheusmetrics.PrometheusMeterRegistry
 import no.nav.dagpenger.rapportering.personregister.mediator.MeldepliktMediator
+import no.nav.dagpenger.rapportering.personregister.mediator.MeldestatusMediator
 import no.nav.dagpenger.rapportering.personregister.mediator.PersonMediator
 import no.nav.dagpenger.rapportering.personregister.mediator.connector.MeldepliktConnector
 import no.nav.dagpenger.rapportering.personregister.mediator.db.PersonRepository
@@ -18,7 +19,7 @@ fun Application.internalApi(
     aktiverHendelserJob: AktiverHendelserJob,
     personRepository: PersonRepository,
     personMediator: PersonMediator,
-    meldepliktMediator: MeldepliktMediator,
+    meldestatusMediator: MeldestatusMediator,
     meldepliktConnector: MeldepliktConnector,
 ) {
     routing {
@@ -35,7 +36,7 @@ fun Application.internalApi(
             call.respondText(meterRegistry.scrape())
         }
         get("/aktiver") {
-            aktiverHendelserJob.aktivererHendelser(personRepository, personMediator, meldepliktMediator, meldepliktConnector)
+            aktiverHendelserJob.aktivererHendelser(personRepository, personMediator, meldestatusMediator, meldepliktConnector)
             call.respond(HttpStatusCode.OK)
         }
     }


### PR DESCRIPTION
for å oppdatere person i stede for selve hendelsen vi har lagret i databasen

Tenker at det er sikrere enn å bruke hendelsen vi har lagret, siden vi ikke vet hvor gammle disse er. Det aller viktigste er at vi oppretthholder riktig status på alle brukere, nå som vi har kjørt en oppdatering mot arena.