### PR TITLE
Legg til meldekortstatus API

### DIFF
--- a/mediator/src/main/kotlin/no/nav/dagpenger/rapportering/personregister/mediator/ApplicationBuilder.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/rapportering/personregister/mediator/ApplicationBuilder.kt
@@ -22,6 +22,7 @@ import no.nav.dagpenger.rapportering.personregister.mediator.Configuration.kafka
 import no.nav.dagpenger.rapportering.personregister.mediator.Configuration.unleash
 import no.nav.dagpenger.rapportering.personregister.mediator.api.behandlingApi
 import no.nav.dagpenger.rapportering.personregister.mediator.api.internalApi
+import no.nav.dagpenger.rapportering.personregister.mediator.api.meldekortStatusApi
 import no.nav.dagpenger.rapportering.personregister.mediator.api.personApi
 import no.nav.dagpenger.rapportering.personregister.mediator.api.personstatusApi
 import no.nav.dagpenger.rapportering.personregister.mediator.connector.ArbeidssøkerConnector
@@ -55,6 +56,7 @@ import no.nav.dagpenger.rapportering.personregister.mediator.observers.Arbeidss�
 import no.nav.dagpenger.rapportering.personregister.mediator.observers.PersonObserverKafka
 import no.nav.dagpenger.rapportering.personregister.mediator.observers.PersonObserverMeldekortregister
 import no.nav.dagpenger.rapportering.personregister.mediator.service.ArbeidssøkerService
+import no.nav.dagpenger.rapportering.personregister.mediator.service.MeldekortStatusService
 import no.nav.dagpenger.rapportering.personregister.mediator.service.PersonService
 import no.nav.dagpenger.rapportering.personregister.mediator.tjenester.ArbeidssøkerMottak
 import no.nav.dagpenger.rapportering.personregister.mediator.tjenester.ArbeidssøkerperiodeOvertakelseMottak
@@ -166,6 +168,7 @@ internal class ApplicationBuilder(
             meldekortregisterConnector,
         )
     private val arbeidssøkerService = ArbeidssøkerService(arbeidssøkerConnector, meldekortregisterConnector)
+    private val meldekortLandingssideService = MeldekortStatusService(meldekortregisterConnector)
     private val arbeidssøkerMediator =
         ArbeidssøkerMediator(
             arbeidssøkerService,
@@ -268,6 +271,7 @@ internal class ApplicationBuilder(
                                 personstatusApi(personMediator, synkroniserPersonMetrikker, personService)
                                 personApi(personService)
                                 behandlingApi(behandlingRepository)
+                                meldekortStatusApi(meldekortLandingssideService)
                             }
                         }
                     },

--- a/mediator/src/main/kotlin/no/nav/dagpenger/rapportering/personregister/mediator/ApplicationBuilder.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/rapportering/personregister/mediator/ApplicationBuilder.kt
@@ -168,7 +168,7 @@ internal class ApplicationBuilder(
             meldekortregisterConnector,
         )
     private val arbeidssøkerService = ArbeidssøkerService(arbeidssøkerConnector, meldekortregisterConnector)
-    private val meldekortStatusService = MeldekortStatusService(meldekortregisterConnector)
+    private val meldekortStatusService = MeldekortStatusService(meldekortregisterConnector, meldepliktConnector)
     private val arbeidssøkerMediator =
         ArbeidssøkerMediator(
             arbeidssøkerService,

--- a/mediator/src/main/kotlin/no/nav/dagpenger/rapportering/personregister/mediator/ApplicationBuilder.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/rapportering/personregister/mediator/ApplicationBuilder.kt
@@ -168,7 +168,7 @@ internal class ApplicationBuilder(
             meldekortregisterConnector,
         )
     private val arbeidssøkerService = ArbeidssøkerService(arbeidssøkerConnector, meldekortregisterConnector)
-    private val meldekortLandingssideService = MeldekortStatusService(meldekortregisterConnector)
+    private val meldekortStatusService = MeldekortStatusService(meldekortregisterConnector)
     private val arbeidssøkerMediator =
         ArbeidssøkerMediator(
             arbeidssøkerService,
@@ -271,7 +271,7 @@ internal class ApplicationBuilder(
                                 personstatusApi(personMediator, synkroniserPersonMetrikker, personService)
                                 personApi(personService)
                                 behandlingApi(behandlingRepository)
-                                meldekortStatusApi(meldekortLandingssideService)
+                                meldekortStatusApi(meldekortStatusService)
                             }
                         }
                     },

--- a/mediator/src/main/kotlin/no/nav/dagpenger/rapportering/personregister/mediator/api/MeldekortStatusApi.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/rapportering/personregister/mediator/api/MeldekortStatusApi.kt
@@ -2,6 +2,7 @@ package no.nav.dagpenger.rapportering.personregister.mediator.api
 
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.http.HttpStatusCode
+import io.ktor.http.HttpStatusCode.Companion.OK
 import io.ktor.server.application.Application
 import io.ktor.server.auth.authenticate
 import io.ktor.server.response.respond
@@ -23,8 +24,8 @@ internal fun Application.meldekortStatusApi(meldekortStatusService: MeldekortSta
         authenticate("tokenX") {
             get("/meldekort/status") {
                 logger.info { "GET /meldekort/status" }
-                val status = meldekortStatusService.hentStatus(call.ident())
-                call.respond(HttpStatusCode.OK, status.tilResponse())
+                val status = meldekortStatusService.hentMeldekortStatus(call.ident())
+                call.respond(OK, status.tilResponse())
             }
         }
     }

--- a/mediator/src/main/kotlin/no/nav/dagpenger/rapportering/personregister/mediator/api/MeldekortStatusApi.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/rapportering/personregister/mediator/api/MeldekortStatusApi.kt
@@ -1,0 +1,46 @@
+package no.nav.dagpenger.rapportering.personregister.mediator.api
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.Application
+import io.ktor.server.auth.authenticate
+import io.ktor.server.response.respond
+import io.ktor.server.routing.get
+import io.ktor.server.routing.routing
+import no.nav.dagpenger.rapportering.personregister.api.models.MeldekortStatusResponse
+import no.nav.dagpenger.rapportering.personregister.api.models.MeldekortTilUtfyllingResponse
+import no.nav.dagpenger.rapportering.personregister.mediator.api.auth.ident
+import no.nav.dagpenger.rapportering.personregister.mediator.connector.MeldekortResponse
+import no.nav.dagpenger.rapportering.personregister.mediator.service.MeldekortStatus
+import no.nav.dagpenger.rapportering.personregister.mediator.service.MeldekortStatusService
+import java.time.LocalDate
+import java.time.ZoneOffset
+
+private val logger = KotlinLogging.logger {}
+
+internal fun Application.meldekortStatusApi(meldekortStatusService: MeldekortStatusService) {
+    routing {
+        authenticate("tokenX") {
+            get("/meldekort/status") {
+                logger.info { "GET /meldekort/status" }
+                val status = meldekortStatusService.hentStatus(call.ident())
+                call.respond(HttpStatusCode.OK, status.tilResponse())
+            }
+        }
+    }
+}
+
+private fun MeldekortStatus.tilResponse() =
+    MeldekortStatusResponse(
+        harInnsendteMeldekort = harInnsendteMeldekort,
+        redirectUrl = redirectUrl,
+        meldekortTilUtfylling = meldekortTilUtfylling.map { it.tilMeldekortTilUtfylling() },
+    )
+
+private fun MeldekortResponse.tilMeldekortTilUtfylling() =
+    MeldekortTilUtfyllingResponse(
+        kanSendesFra = kanSendesFra.tilOffsetDateTime(),
+        fristForInnsending = sisteFristForTrekk.tilOffsetDateTime(),
+    )
+
+private fun LocalDate.tilOffsetDateTime() = atStartOfDay().atOffset(ZoneOffset.UTC)

--- a/mediator/src/main/kotlin/no/nav/dagpenger/rapportering/personregister/mediator/api/MeldekortStatusApi.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/rapportering/personregister/mediator/api/MeldekortStatusApi.kt
@@ -24,8 +24,13 @@ internal fun Application.meldekortStatusApi(meldekortStatusService: MeldekortSta
         authenticate("tokenX") {
             get("/meldekort/status") {
                 logger.info { "GET /meldekort/status" }
-                val status = meldekortStatusService.hentMeldekortStatus(call.ident())
-                call.respond(OK, status.tilResponse())
+                try {
+                    val status = meldekortStatusService.hentMeldekortStatus(call.ident())
+                    call.respond(OK, status.tilResponse())
+                } catch (e: Exception) {
+                    logger.error(e) { "Feil ved henting av meldekortstatus" }
+                    call.respond(HttpStatusCode.InternalServerError)
+                }
             }
         }
     }

--- a/mediator/src/main/kotlin/no/nav/dagpenger/rapportering/personregister/mediator/connector/MeldekortregisterConnector.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/rapportering/personregister/mediator/connector/MeldekortregisterConnector.kt
@@ -5,6 +5,8 @@ import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpStatusCode
+import io.ktor.http.HttpStatusCode.Companion.NotFound
+import io.ktor.http.HttpStatusCode.Companion.OK
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import no.nav.dagpenger.rapportering.personregister.mediator.Configuration
@@ -36,7 +38,7 @@ class MeldekortregisterConnector(
                 logger.info { "Kall til meldekortregister for å oppdatere ident ga status ${it.status}" }
             }
 
-        if (result.status != HttpStatusCode.OK) {
+        if (result.status != OK) {
             logger.error { "Uforventet status ${result.status.value} ved oppdatering av ident i meldekortregister" }
             sikkerLogg.error { "Uforventet status ved oppdatering av ident i meldekortregister. Response: $result" }
             throw RuntimeException("Uforventet status ${result.status.value} ved oppdatering av ident i meldekortregister")
@@ -63,7 +65,7 @@ class MeldekortregisterConnector(
                 logger.info { "Kall til meldekortregister for å konsolidere identer ga status ${it.status}" }
             }
 
-        if (result.status != HttpStatusCode.OK) {
+        if (result.status != OK) {
             logger.error { "Uforventet status ${result.status.value} ved konsolidering av identer i meldekortregister" }
             sikkerLogg.error { "Uforventet status ved konsolidering av identer i meldekortregister. Response: $result" }
             throw RuntimeException("Uforventet status ${result.status.value} ved konsolidering av identer i meldekortregister")
@@ -88,13 +90,19 @@ class MeldekortregisterConnector(
                 }
 
             when (response.status) {
-                HttpStatusCode.OK -> response.body<List<MeldekortResponse>>()
-                HttpStatusCode.NotFound -> emptyList()
+                OK -> {
+                    response.body<List<MeldekortResponse>>()
+                }
+
+                NotFound -> {
+                    emptyList()
+                }
+
                 else -> {
                     val body = response.bodyAsText()
-                    logger.error { "Uforventet status ${response.status.value} ved henting av meldekort. Response body: $body" }
+                    logger.error { "Uventet status ${response.status.value} ved henting av meldekort. Response body: $body" }
                     throw RuntimeException(
-                        "Uforventet status ${response.status.value} ved henting av meldekort i meldekortregister",
+                        "Uventet status ${response.status.value} ved henting av meldekort i meldekortregister",
                     )
                 }
             }
@@ -118,13 +126,13 @@ class MeldekortregisterConnector(
                 }
 
             when (response.status) {
-                HttpStatusCode.OK -> {
+                OK -> {
                     response
                         .body<List<InnsendtMeldekortResponse>>()
                         .maxByOrNull { it.innsendtTidspunkt }
                 }
 
-                HttpStatusCode.NotFound -> {
+                NotFound -> {
                     null
                 }
 

--- a/mediator/src/main/kotlin/no/nav/dagpenger/rapportering/personregister/mediator/connector/MeldekortregisterConnector.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/rapportering/personregister/mediator/connector/MeldekortregisterConnector.kt
@@ -70,6 +70,36 @@ class MeldekortregisterConnector(
         }
     }
 
+    suspend fun hentMeldekort(ident: String): List<MeldekortResponse> =
+        withContext(Dispatchers.IO) {
+            val response =
+                sendGetRequest(
+                    httpClient = httpClient,
+                    endpointUrl = "$meldekortregisterUrl/meldekort",
+                    token =
+                        meldekortregisterTokenProvider.invoke()
+                            ?: throw RuntimeException("Klarte ikke å hente token"),
+                    metrikkNavn = "meldekortregister_hentMeldekort",
+                    parameters = mapOf("ident" to ident),
+                    headers = mapOf(),
+                    actionTimer = actionTimer,
+                ).also {
+                    logger.info { "Kall til meldekortregister for å hente meldekort ga status ${it.status}" }
+                }
+
+            when (response.status) {
+                HttpStatusCode.OK -> response.body<List<MeldekortResponse>>()
+                HttpStatusCode.NotFound -> emptyList()
+                else -> {
+                    val body = response.bodyAsText()
+                    logger.error { "Uforventet status ${response.status.value} ved henting av meldekort. Response body: $body" }
+                    throw RuntimeException(
+                        "Uforventet status ${response.status.value} ved henting av meldekort i meldekortregister",
+                    )
+                }
+            }
+        }
+
     suspend fun hentSisteInnsendteMeldekort(ident: String): InnsendtMeldekortResponse? =
         withContext(Dispatchers.IO) {
             val response =

--- a/mediator/src/main/kotlin/no/nav/dagpenger/rapportering/personregister/mediator/connector/MeldepliktConnector.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/rapportering/personregister/mediator/connector/MeldepliktConnector.kt
@@ -84,7 +84,7 @@ class MeldepliktConnector(
             }
         }
 
-    suspend fun hentMeldekortFraArena(ident: String): List<ArenaMeldekortResponse>? =
+    suspend fun hentMeldekortFraArena(ident: String): List<ArenaMeldekortResponse> =
         withContext(Dispatchers.IO) {
             val response =
                 sendGetRequest(

--- a/mediator/src/main/kotlin/no/nav/dagpenger/rapportering/personregister/mediator/connector/MeldepliktConnector.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/rapportering/personregister/mediator/connector/MeldepliktConnector.kt
@@ -3,8 +3,12 @@ package no.nav.dagpenger.rapportering.personregister.mediator.connector
 import com.fasterxml.jackson.module.kotlin.readValue
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.client.HttpClient
+import io.ktor.client.call.body
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpStatusCode
+import io.ktor.http.HttpStatusCode.Companion.NoContent
+import io.ktor.http.HttpStatusCode.Companion.NotFound
+import io.ktor.http.HttpStatusCode.Companion.OK
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import no.nav.dagpenger.rapportering.personregister.mediator.Configuration
@@ -65,15 +69,55 @@ class MeldepliktConnector(
                 }
 
             when (result.status) {
-                HttpStatusCode.OK -> {
+                OK -> {
                     defaultObjectMapper.readValue<MeldestatusResponse>(result.bodyAsText())
                 }
-                HttpStatusCode.NoContent -> {
+
+                NoContent -> {
                     null
                 }
+
                 else -> {
                     logger.error { "Uforventet status ${result.status.value} ved henting av meldestatus fra adapter" }
                     throw RuntimeException("Uforventet status ${result.status.value} ved henting av meldestatus fra adapter")
+                }
+            }
+        }
+
+    suspend fun hentMeldekortFraArena(ident: String): List<ArenaMeldekortResponse>? =
+        withContext(Dispatchers.IO) {
+            val response =
+                sendGetRequest(
+                    httpClient = httpClient,
+                    endpointUrl = "$meldepliktAdapterUrl/rapporteringsperioder",
+                    token =
+                        meldepliktAdapterTokenProvider.invoke()
+                            ?: throw RuntimeException("Klarte ikke å hente token"),
+                    metrikkNavn = "meldepliktadapter_hentArenaMeldekort",
+                    parameters = mapOf("ident" to ident),
+                    headers = mapOf(),
+                    actionTimer = actionTimer,
+                ).also {
+                    logger.info { "Kall til adapter for å hente meldekort ga status ${it.status}" }
+                }
+
+            when (response.status) {
+                OK -> {
+                    response.body<List<ArenaMeldekortResponse>>()
+                }
+
+                NotFound -> {
+                    emptyList()
+                }
+
+                else -> {
+                    val body = response.bodyAsText()
+                    logger.error {
+                        "Uventet status ${response.status.value} ved henting av meldekort fra adapter. Response body: $body"
+                    }
+                    throw RuntimeException(
+                        "Uventet status ${response.status.value} ved henting av meldekort fra adapter",
+                    )
                 }
             }
         }

--- a/mediator/src/main/kotlin/no/nav/dagpenger/rapportering/personregister/mediator/connector/Model.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/rapportering/personregister/mediator/connector/Model.kt
@@ -1,5 +1,6 @@
 package no.nav.dagpenger.rapportering.personregister.mediator.connector
 
+import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -38,6 +39,12 @@ data class BrukerResponse(
 data class TidspunktFraKildeResponse(
     val tidspunkt: OffsetDateTime,
     val avviksType: String,
+)
+
+data class MeldekortResponse(
+    val status: String,
+    val kanSendesFra: LocalDate,
+    val sisteFristForTrekk: LocalDate,
 )
 
 data class InnsendtMeldekortResponse(

--- a/mediator/src/main/kotlin/no/nav/dagpenger/rapportering/personregister/mediator/connector/Model.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/rapportering/personregister/mediator/connector/Model.kt
@@ -47,6 +47,11 @@ data class MeldekortResponse(
     val sisteFristForTrekk: LocalDate,
 )
 
+data class ArenaMeldekortResponse(
+    val status: String,
+    val kanSendesFra: LocalDate,
+)
+
 data class InnsendtMeldekortResponse(
     val fraOgMed: LocalDateTime,
     val tilOgMed: LocalDateTime,

--- a/mediator/src/main/kotlin/no/nav/dagpenger/rapportering/personregister/mediator/service/MeldekortStatusService.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/rapportering/personregister/mediator/service/MeldekortStatusService.kt
@@ -1,13 +1,13 @@
 package no.nav.dagpenger.rapportering.personregister.mediator.service
 
-import io.github.oshai.kotlinlogging.KotlinLogging
+import no.nav.dagpenger.rapportering.personregister.mediator.connector.ArenaMeldekortResponse
 import no.nav.dagpenger.rapportering.personregister.mediator.connector.MeldekortResponse
 import no.nav.dagpenger.rapportering.personregister.mediator.connector.MeldekortregisterConnector
-
-private val logger = KotlinLogging.logger {}
+import no.nav.dagpenger.rapportering.personregister.mediator.connector.MeldepliktConnector
 
 class MeldekortStatusService(
     private val meldekortregisterConnector: MeldekortregisterConnector,
+    private val meldepliktConnector: MeldepliktConnector,
 ) {
     suspend fun hentMeldekortStatus(ident: String): MeldekortStatus =
         hentFraMeldekortregister(ident)
@@ -18,35 +18,46 @@ class MeldekortStatusService(
                 redirectUrl = RedirectUrl.INGEN.url,
             )
 
-    private suspend fun hentFraMeldekortregister(ident: String): MeldekortStatus? =
-        try {
-            val meldekort = meldekortregisterConnector.hentMeldekort(ident)
-            val harInnsendte = meldekort.harInnsendte()
-            val tilUtfylling = meldekort.tilUtfylling()
-
-            if (meldekort.isEmpty()) {
-                null
-            } else {
-                MeldekortStatus(
-                    harInnsendteMeldekort = harInnsendte,
-                    meldekortTilUtfylling = tilUtfylling,
-                    redirectUrl = RedirectUrl.DP_MELDEKORT.url,
-                )
-            }
-        } catch (e: Exception) {
-            logger.warn(e) { "Meldekortregister feilet for ident, faller tilbake på Arena" }
-            null
-        }
+    private suspend fun hentFraMeldekortregister(ident: String): MeldekortStatus? {
+        val meldekort = meldekortregisterConnector.hentMeldekort(ident)
+        if (meldekort.isEmpty()) return null
+        return MeldekortStatus(
+            harInnsendteMeldekort = meldekort.harInnsendte(),
+            meldekortTilUtfylling = meldekort.tilUtfylling(),
+            redirectUrl = RedirectUrl.DP_MELDEKORT.url,
+        )
+    }
 
     private suspend fun hentFraArena(ident: String): MeldekortStatus? {
-        // TODO: Implementeres senere
-        return null
+        val meldekort = meldepliktConnector.hentMeldekortFraArena(ident)
+        if (meldekort.isEmpty()) return null
+        val harInnsendte = meldekort.harInnsendte()
+        val tilUtfylling = meldekort.tilUtfylling()
+        return MeldekortStatus(
+            harInnsendteMeldekort = harInnsendte,
+            meldekortTilUtfylling = tilUtfylling.map {
+                MeldekortResponse(
+                    status = it.status,
+                    kanSendesFra = it.kanSendesFra,
+                    sisteFristForTrekk = it.kanSendesFra.plusDays(9),
+                )
+            },
+            redirectUrl = if (harInnsendte || tilUtfylling.isNotEmpty()) RedirectUrl.DP_MELDEKORT.url else RedirectUrl.FELLES_MELDEKORT.url,
+        )
     }
 }
 
+@JvmName("meldekortHarInnsendte")
 private fun List<MeldekortResponse>.harInnsendte() = any { it.status == "Innsendt" }
 
+@JvmName("arenaHarInnsendte")
+private fun List<ArenaMeldekortResponse>.harInnsendte() = any { it.status == "Innsendt" }
+
+@JvmName("meldekortTilUtfylling")
 private fun List<MeldekortResponse>.tilUtfylling() = filter { it.status == "TilUtfylling" }
+
+@JvmName("arenaTilUtfylling")
+private fun List<ArenaMeldekortResponse>.tilUtfylling() = filter { it.status == "TilUtfylling" }
 
 data class MeldekortStatus(
     val harInnsendteMeldekort: Boolean,
@@ -60,17 +71,4 @@ private enum class RedirectUrl(
     DP_MELDEKORT("/arbeid/dagpenger/meldekort"),
     FELLES_MELDEKORT("/felles-meldekort"),
     INGEN(""),
-    ;
-
-    companion object {
-        fun fra(
-            harTilUtfylling: Boolean,
-            harInnsendte: Boolean,
-        ): RedirectUrl =
-            when {
-                harTilUtfylling -> DP_MELDEKORT
-                harInnsendte -> FELLES_MELDEKORT
-                else -> INGEN
-            }
-    }
 }

--- a/mediator/src/main/kotlin/no/nav/dagpenger/rapportering/personregister/mediator/service/MeldekortStatusService.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/rapportering/personregister/mediator/service/MeldekortStatusService.kt
@@ -9,7 +9,7 @@ private val logger = KotlinLogging.logger {}
 class MeldekortStatusService(
     private val meldekortregisterConnector: MeldekortregisterConnector,
 ) {
-    suspend fun hentStatus(ident: String): MeldekortStatus =
+    suspend fun hentMeldekortStatus(ident: String): MeldekortStatus =
         hentFraMeldekortregister(ident)
             ?: hentFraArena(ident)
             ?: MeldekortStatus(

--- a/mediator/src/main/kotlin/no/nav/dagpenger/rapportering/personregister/mediator/service/MeldekortStatusService.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/rapportering/personregister/mediator/service/MeldekortStatusService.kt
@@ -1,0 +1,76 @@
+package no.nav.dagpenger.rapportering.personregister.mediator.service
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import no.nav.dagpenger.rapportering.personregister.mediator.connector.MeldekortResponse
+import no.nav.dagpenger.rapportering.personregister.mediator.connector.MeldekortregisterConnector
+
+private val logger = KotlinLogging.logger {}
+
+class MeldekortStatusService(
+    private val meldekortregisterConnector: MeldekortregisterConnector,
+) {
+    suspend fun hentStatus(ident: String): MeldekortStatus =
+        hentFraMeldekortregister(ident)
+            ?: hentFraArena(ident)
+            ?: MeldekortStatus(
+                harInnsendteMeldekort = false,
+                meldekortTilUtfylling = emptyList(),
+                redirectUrl = RedirectUrl.INGEN.url,
+            )
+
+    private suspend fun hentFraMeldekortregister(ident: String): MeldekortStatus? =
+        try {
+            val meldekort = meldekortregisterConnector.hentMeldekort(ident)
+            val harInnsendte = meldekort.harInnsendte()
+            val tilUtfylling = meldekort.tilUtfylling()
+
+            if (meldekort.isEmpty()) {
+                null
+            } else {
+                MeldekortStatus(
+                    harInnsendteMeldekort = harInnsendte,
+                    meldekortTilUtfylling = tilUtfylling,
+                    redirectUrl = RedirectUrl.DP_MELDEKORT.url,
+                )
+            }
+        } catch (e: Exception) {
+            logger.warn(e) { "Meldekortregister feilet for ident, faller tilbake på Arena" }
+            null
+        }
+
+    private suspend fun hentFraArena(ident: String): MeldekortStatus? {
+        // TODO: Implementeres senere
+        return null
+    }
+}
+
+private fun List<MeldekortResponse>.harInnsendte() = any { it.status == "Innsendt" }
+
+private fun List<MeldekortResponse>.tilUtfylling() = filter { it.status == "TilUtfylling" }
+
+data class MeldekortStatus(
+    val harInnsendteMeldekort: Boolean,
+    val meldekortTilUtfylling: List<MeldekortResponse>,
+    val redirectUrl: String,
+)
+
+private enum class RedirectUrl(
+    val url: String,
+) {
+    DP_MELDEKORT("/arbeid/dagpenger/meldekort"),
+    FELLES_MELDEKORT("/felles-meldekort"),
+    INGEN(""),
+    ;
+
+    companion object {
+        fun fra(
+            harTilUtfylling: Boolean,
+            harInnsendte: Boolean,
+        ): RedirectUrl =
+            when {
+                harTilUtfylling -> DP_MELDEKORT
+                harInnsendte -> FELLES_MELDEKORT
+                else -> INGEN
+            }
+    }
+}

--- a/mediator/src/test/kotlin/no/nav/dagpenger/rapportering/personregister/mediator/api/ApiTestSetup.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/rapportering/personregister/mediator/api/ApiTestSetup.kt
@@ -179,7 +179,7 @@ open class ApiTestSetup {
                 personstatusApi(personMediator, synkroniserPersonMetrikker, personService)
                 personApi(personService)
                 behandlingApi(behandlingRepository)
-                meldekortStatusApi(MeldekortStatusService(meldekortregisterConnector))
+                meldekortStatusApi(MeldekortStatusService(meldekortregisterConnector, meldepliktConnector))
             }
 
             block()

--- a/mediator/src/test/kotlin/no/nav/dagpenger/rapportering/personregister/mediator/api/ApiTestSetup.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/rapportering/personregister/mediator/api/ApiTestSetup.kt
@@ -34,6 +34,7 @@ import no.nav.dagpenger.rapportering.personregister.mediator.db.PostgresDataSour
 import no.nav.dagpenger.rapportering.personregister.mediator.db.PostgresDataSourceBuilder.runMigration
 import no.nav.dagpenger.rapportering.personregister.mediator.pluginConfiguration
 import no.nav.dagpenger.rapportering.personregister.mediator.service.ArbeidssøkerService
+import no.nav.dagpenger.rapportering.personregister.mediator.service.MeldekortStatusService
 import no.nav.dagpenger.rapportering.personregister.mediator.service.PersonService
 import no.nav.dagpenger.rapportering.personregister.mediator.statusPagesConfig
 import no.nav.dagpenger.rapportering.personregister.mediator.tjenester.ArbeidssøkerMottak
@@ -178,6 +179,7 @@ open class ApiTestSetup {
                 personstatusApi(personMediator, synkroniserPersonMetrikker, personService)
                 personApi(personService)
                 behandlingApi(behandlingRepository)
+                meldekortStatusApi(MeldekortStatusService(meldekortregisterConnector))
             }
 
             block()

--- a/mediator/src/test/kotlin/no/nav/dagpenger/rapportering/personregister/mediator/api/MeldekortStatusApiTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/rapportering/personregister/mediator/api/MeldekortStatusApiTest.kt
@@ -1,0 +1,99 @@
+package no.nav.dagpenger.rapportering.personregister.mediator.api
+
+import io.kotest.matchers.shouldBe
+import io.ktor.client.request.bearerAuth
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
+import io.mockk.coEvery
+import no.nav.dagpenger.rapportering.personregister.mediator.Configuration.defaultObjectMapper
+import no.nav.dagpenger.rapportering.personregister.mediator.connector.MeldekortResponse
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+class MeldekortStatusApiTest : ApiTestSetup() {
+    private val ident = "12345678901"
+    private val idag = LocalDate.now()
+
+    @Test
+    fun `uten token gir 401`() =
+        setUpTestApplication {
+            client.get("/meldekort/status").status shouldBe HttpStatusCode.Unauthorized
+        }
+
+    @Test
+    fun `har innsendte og meldekort til utfylling`() =
+        setUpTestApplication {
+            coEvery { meldekortregisterConnector.hentMeldekort(ident) } returns
+                listOf(
+                    innsendtMeldekort(),
+                    meldekortTilUtfylling(kanSendesFra = idag, sisteFristForTrekk = idag.plusDays(7)),
+                )
+
+            with(client.get("/meldekort/status") { bearerAuth(issueTokenX(ident)) }) {
+                status shouldBe HttpStatusCode.OK
+                val body = defaultObjectMapper.readTree(bodyAsText())
+                body["harInnsendteMeldekort"].asBoolean() shouldBe true
+                body["meldekortTilUtfylling"].size() shouldBe 1
+                body["redirectUrl"].asText() shouldBe "/arbeid/dagpenger/meldekort"
+            }
+        }
+
+    @Test
+    fun `har innsendte men ingen meldekort til utfylling`() =
+        setUpTestApplication {
+            coEvery { meldekortregisterConnector.hentMeldekort(ident) } returns listOf(innsendtMeldekort())
+
+            with(client.get("/meldekort/status") { bearerAuth(issueTokenX(ident)) }) {
+                status shouldBe HttpStatusCode.OK
+                val body = defaultObjectMapper.readTree(bodyAsText())
+                body["harInnsendteMeldekort"].asBoolean() shouldBe true
+                body["meldekortTilUtfylling"].size() shouldBe 0
+                body["redirectUrl"].asText() shouldBe "/arbeid/dagpenger/meldekort"
+            }
+        }
+
+    @Test
+    fun `ingen meldekort gir tom respons`() =
+        setUpTestApplication {
+            coEvery { meldekortregisterConnector.hentMeldekort(ident) } returns emptyList()
+
+            with(client.get("/meldekort/status") { bearerAuth(issueTokenX(ident)) }) {
+                status shouldBe HttpStatusCode.OK
+                val body = defaultObjectMapper.readTree(bodyAsText())
+                body["harInnsendteMeldekort"].asBoolean() shouldBe false
+                body["meldekortTilUtfylling"].size() shouldBe 0
+                body["redirectUrl"].asText() shouldBe ""
+            }
+        }
+
+    @Test
+    fun `datofelter mappes til riktig format`() =
+        setUpTestApplication {
+            coEvery { meldekortregisterConnector.hentMeldekort(ident) } returns
+                listOf(meldekortTilUtfylling(kanSendesFra = idag, sisteFristForTrekk = idag.plusDays(13)))
+
+            with(client.get("/meldekort/status") { bearerAuth(issueTokenX(ident)) }) {
+                status shouldBe HttpStatusCode.OK
+                val meldekort = defaultObjectMapper.readTree(bodyAsText())["meldekortTilUtfylling"][0]
+                meldekort["kanSendesFra"].asText() shouldBe "${idag}T00:00:00Z"
+                meldekort["fristForInnsending"].asText() shouldBe "${idag.plusDays(13)}T00:00:00Z"
+            }
+        }
+
+    private fun innsendtMeldekort() =
+        MeldekortResponse(
+            status = "Innsendt",
+            kanSendesFra = idag.minusDays(14),
+            sisteFristForTrekk = idag.minusDays(7),
+        )
+
+    private fun meldekortTilUtfylling(
+        kanSendesFra: LocalDate,
+        sisteFristForTrekk: LocalDate,
+    ) = MeldekortResponse(
+        status = "TilUtfylling",
+        kanSendesFra = kanSendesFra,
+        sisteFristForTrekk = sisteFristForTrekk,
+    )
+}

--- a/mediator/src/test/kotlin/no/nav/dagpenger/rapportering/personregister/mediator/api/MeldekortStatusApiTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/rapportering/personregister/mediator/api/MeldekortStatusApiTest.kt
@@ -68,6 +68,14 @@ class MeldekortStatusApiTest : ApiTestSetup() {
         }
 
     @Test
+    fun `krasj i service gir 503`() =
+        setUpTestApplication {
+            coEvery { meldekortregisterConnector.hentMeldekort(ident) } throws RuntimeException("utilgjengelig")
+
+            client.get("/meldekort/status") { bearerAuth(issueTokenX(ident)) }.status shouldBe HttpStatusCode.InternalServerError
+        }
+
+    @Test
     fun `datofelter mappes til riktig format`() =
         setUpTestApplication {
             coEvery { meldekortregisterConnector.hentMeldekort(ident) } returns

--- a/mediator/src/test/kotlin/no/nav/dagpenger/rapportering/personregister/mediator/connector/MeldekortregisterConnectorTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/rapportering/personregister/mediator/connector/MeldekortregisterConnectorTest.kt
@@ -6,7 +6,9 @@ import io.kotest.matchers.shouldNotBe
 import kotlinx.coroutines.runBlocking
 import no.nav.dagpenger.rapportering.personregister.mediator.Configuration.defaultObjectMapper
 import no.nav.dagpenger.rapportering.personregister.mediator.utils.MetrikkerTestUtil.actionTimer
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import java.time.LocalDate
 import java.time.LocalDateTime
 
 class MeldekortregisterConnectorTest {
@@ -26,6 +28,52 @@ class MeldekortregisterConnectorTest {
         httpClient = createMockClient(statusCode, responseBody),
         actionTimer = actionTimer,
     )
+
+    @Nested
+    inner class HentMeldekort {
+        private val ident = "12345678901"
+        private val idag = LocalDate.now()
+
+        @Test
+        fun `returnerer liste med meldekort ved 200`() {
+            val body =
+                defaultObjectMapper.writeValueAsString(
+                    listOf(
+                        MeldekortResponse("Innsendt", idag.minusDays(14), idag.minusDays(7)),
+                        MeldekortResponse("TilUtfylling", idag, idag.plusDays(7)),
+                    ),
+                )
+
+            val result = runBlocking { connector(body, 200).hentMeldekort(ident) }
+
+            result.size shouldBe 2
+            result[0].status shouldBe "Innsendt"
+            result[1].status shouldBe "TilUtfylling"
+            result[1].kanSendesFra shouldBe idag
+            result[1].sisteFristForTrekk shouldBe idag.plusDays(7)
+        }
+
+        @Test
+        fun `returnerer tom liste ved tom respons`() {
+            val result = runBlocking { connector("[]", 200).hentMeldekort(ident) }
+
+            result shouldBe emptyList()
+        }
+
+        @Test
+        fun `returnerer tom liste ved 404`() {
+            val result = runBlocking { connector("{}", 404).hentMeldekort(ident) }
+
+            result shouldBe emptyList()
+        }
+
+        @Test
+        fun `kaster exception ved uventet statuskode`() {
+            shouldThrow<RuntimeException> {
+                runBlocking { connector("{}", 500).hentMeldekort(ident) }
+            }
+        }
+    }
 
     @Test
     fun `returnerer seneste innsendtmeldekort`() {

--- a/mediator/src/test/kotlin/no/nav/dagpenger/rapportering/personregister/mediator/connector/MeldepliktConnectorTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/rapportering/personregister/mediator/connector/MeldepliktConnectorTest.kt
@@ -6,7 +6,9 @@ import kotlinx.coroutines.runBlocking
 import no.nav.dagpenger.rapportering.personregister.mediator.Configuration.defaultObjectMapper
 import no.nav.dagpenger.rapportering.personregister.mediator.utils.MetrikkerTestUtil.actionTimer
 import no.nav.dagpenger.rapportering.personregister.modell.meldestatus.MeldestatusResponse
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import java.time.LocalDate
 import java.time.LocalDateTime
 
 class MeldepliktConnectorTest {
@@ -102,6 +104,51 @@ class MeldepliktConnectorTest {
         shouldThrow<RuntimeException> {
             runBlocking {
                 meldepliktConnector("false", 500).hentMeldestatus(1L)
+            }
+        }
+    }
+
+    @Nested
+    inner class HentMeldekortFraArena {
+        private val ident = "12345678901"
+        private val idag = LocalDate.now()
+
+        @Test
+        fun `returnerer liste med meldekort ved 200`() {
+            val body =
+                defaultObjectMapper.writeValueAsString(
+                    listOf(
+                        ArenaMeldekortResponse("Innsendt", idag.minusDays(14)),
+                        ArenaMeldekortResponse("TilUtfylling", idag),
+                    ),
+                )
+
+            val result = runBlocking { meldepliktConnector(body, 200).hentMeldekortFraArena(ident) }
+
+            result!!.size shouldBe 2
+            result[0].status shouldBe "Innsendt"
+            result[1].status shouldBe "TilUtfylling"
+            result[1].kanSendesFra shouldBe idag
+        }
+
+        @Test
+        fun `returnerer tom liste ved tom respons`() {
+            val result = runBlocking { meldepliktConnector("[]", 200).hentMeldekortFraArena(ident) }
+
+            result shouldBe emptyList()
+        }
+
+        @Test
+        fun `returnerer tom liste ved 404`() {
+            val result = runBlocking { meldepliktConnector("{}", 404).hentMeldekortFraArena(ident) }
+
+            result shouldBe emptyList()
+        }
+
+        @Test
+        fun `kaster exception ved uventet statuskode`() {
+            shouldThrow<RuntimeException> {
+                runBlocking { meldepliktConnector("{}", 500).hentMeldekortFraArena(ident) }
             }
         }
     }

--- a/mediator/src/test/kotlin/no/nav/dagpenger/rapportering/personregister/mediator/connector/MeldepliktConnectorTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/rapportering/personregister/mediator/connector/MeldepliktConnectorTest.kt
@@ -125,7 +125,7 @@ class MeldepliktConnectorTest {
 
             val result = runBlocking { meldepliktConnector(body, 200).hentMeldekortFraArena(ident) }
 
-            result!!.size shouldBe 2
+            result.size shouldBe 2
             result[0].status shouldBe "Innsendt"
             result[1].status shouldBe "TilUtfylling"
             result[1].kanSendesFra shouldBe idag

--- a/mediator/src/test/kotlin/no/nav/dagpenger/rapportering/personregister/mediator/service/MeldekortStatusServiceTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/rapportering/personregister/mediator/service/MeldekortStatusServiceTest.kt
@@ -24,7 +24,7 @@ class MeldekortStatusServiceTest {
                 meldekortTilUtfylling(kanSendesFra = idag, sisteFristForTrekk = idag.plusDays(7)),
             )
 
-        val response = runBlocking { service.hentStatus(ident) }
+        val response = runBlocking { service.hentMeldekortStatus(ident) }
 
         response.harInnsendteMeldekort shouldBe true
         response.meldekortTilUtfylling.size shouldBe 1
@@ -38,7 +38,7 @@ class MeldekortStatusServiceTest {
                 innsendtMeldekort(),
             )
 
-        val response = runBlocking { service.hentStatus(ident) }
+        val response = runBlocking { service.hentMeldekortStatus(ident) }
 
         response.harInnsendteMeldekort shouldBe true
         response.meldekortTilUtfylling shouldBe emptyList()
@@ -52,7 +52,7 @@ class MeldekortStatusServiceTest {
                 meldekortTilUtfylling(kanSendesFra = idag, sisteFristForTrekk = idag.plusDays(7)),
             )
 
-        val response = runBlocking { service.hentStatus(ident) }
+        val response = runBlocking { service.hentMeldekortStatus(ident) }
 
         response.harInnsendteMeldekort shouldBe false
         response.meldekortTilUtfylling.size shouldBe 1
@@ -63,7 +63,7 @@ class MeldekortStatusServiceTest {
     fun `ingen innsendte og ingen meldekort til utfylling - ingen redirect`() {
         coEvery { meldekortregisterConnector.hentMeldekort(ident) } returns emptyList()
 
-        val response = runBlocking { service.hentStatus(ident) }
+        val response = runBlocking { service.hentMeldekortStatus(ident) }
 
         response.harInnsendteMeldekort shouldBe false
         response.meldekortTilUtfylling shouldBe emptyList()
@@ -71,10 +71,10 @@ class MeldekortStatusServiceTest {
     }
 
     @Test
-    fun `returnerer tom default response når register feiler`() {
+    fun `returnerer tom default response når kall til meldekortregister feiler`() {
         coEvery { meldekortregisterConnector.hentMeldekort(ident) } throws RuntimeException("Meldekortregister utilgjengelig")
 
-        val response = runBlocking { service.hentStatus(ident) }
+        val response = runBlocking { service.hentMeldekortStatus(ident) }
 
         response.harInnsendteMeldekort shouldBe false
         response.meldekortTilUtfylling shouldBe emptyList()

--- a/mediator/src/test/kotlin/no/nav/dagpenger/rapportering/personregister/mediator/service/MeldekortStatusServiceTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/rapportering/personregister/mediator/service/MeldekortStatusServiceTest.kt
@@ -1,99 +1,166 @@
 package no.nav.dagpenger.rapportering.personregister.mediator.service
 
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
+import no.nav.dagpenger.rapportering.personregister.mediator.connector.ArenaMeldekortResponse
 import no.nav.dagpenger.rapportering.personregister.mediator.connector.MeldekortResponse
 import no.nav.dagpenger.rapportering.personregister.mediator.connector.MeldekortregisterConnector
+import no.nav.dagpenger.rapportering.personregister.mediator.connector.MeldepliktConnector
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
 
 class MeldekortStatusServiceTest {
     private val meldekortregisterConnector = mockk<MeldekortregisterConnector>()
-    private val service = MeldekortStatusService(meldekortregisterConnector)
+    private val meldepliktConnector = mockk<MeldepliktConnector>()
+    private val service = MeldekortStatusService(meldekortregisterConnector, meldepliktConnector)
 
     private val ident = "12345678901"
     private val idag = LocalDate.now()
 
-    @Test
-    fun `har innsendte og meldekort til utfylling - redirect til meldekortflate`() {
-        coEvery { meldekortregisterConnector.hentMeldekort(ident) } returns
-            listOf(
-                innsendtMeldekort(),
-                meldekortTilUtfylling(kanSendesFra = idag, sisteFristForTrekk = idag.plusDays(7)),
-            )
+    @Nested
+    inner class HentFraMeldekortregister {
+        @Test
+        fun `innsendt og til utfylling - redirect DP_MELDEKORT`() {
+            coEvery { meldekortregisterConnector.hentMeldekort(ident) } returns
+                listOf(innsendtMeldekort(), meldekortTilUtfylling())
 
-        val response = runBlocking { service.hentMeldekortStatus(ident) }
+            val response = runBlocking { service.hentMeldekortStatus(ident) }
 
-        response.harInnsendteMeldekort shouldBe true
-        response.meldekortTilUtfylling.size shouldBe 1
-        response.redirectUrl shouldBe "/arbeid/dagpenger/meldekort"
+            response.harInnsendteMeldekort shouldBe true
+            response.meldekortTilUtfylling.size shouldBe 1
+            response.redirectUrl shouldBe "/arbeid/dagpenger/meldekort"
+        }
+
+        @Test
+        fun `kun innsendt - redirect DP_MELDEKORT`() {
+            coEvery { meldekortregisterConnector.hentMeldekort(ident) } returns listOf(innsendtMeldekort())
+
+            val response = runBlocking { service.hentMeldekortStatus(ident) }
+
+            response.harInnsendteMeldekort shouldBe true
+            response.meldekortTilUtfylling shouldBe emptyList()
+            response.redirectUrl shouldBe "/arbeid/dagpenger/meldekort"
+        }
+
+        @Test
+        fun `kun til utfylling - redirect DP_MELDEKORT`() {
+            coEvery { meldekortregisterConnector.hentMeldekort(ident) } returns listOf(meldekortTilUtfylling())
+
+            val response = runBlocking { service.hentMeldekortStatus(ident) }
+
+            response.harInnsendteMeldekort shouldBe false
+            response.meldekortTilUtfylling.size shouldBe 1
+            response.redirectUrl shouldBe "/arbeid/dagpenger/meldekort"
+        }
     }
 
-    @Test
-    fun `har innsendte men ingen meldekort til utfylling - redirect til meldekortflate`() {
-        coEvery { meldekortregisterConnector.hentMeldekort(ident) } returns
-            listOf(
-                innsendtMeldekort(),
-            )
+    @Nested
+    inner class HentFraArena {
+        init {
+            coEvery { meldekortregisterConnector.hentMeldekort(ident) } returns emptyList()
+        }
 
-        val response = runBlocking { service.hentMeldekortStatus(ident) }
+        @Test
+        fun `innsendt og til utfylling - redirect DP_MELDEKORT`() {
+            coEvery { meldepliktConnector.hentMeldekortFraArena(ident) } returns
+                listOf(arenaMeldekortInnsendt(), arenaMeldekortTilUtfylling())
 
-        response.harInnsendteMeldekort shouldBe true
-        response.meldekortTilUtfylling shouldBe emptyList()
-        response.redirectUrl shouldBe "/arbeid/dagpenger/meldekort"
+            val response = runBlocking { service.hentMeldekortStatus(ident) }
+
+            response.harInnsendteMeldekort shouldBe true
+            response.meldekortTilUtfylling.size shouldBe 1
+            response.redirectUrl shouldBe "/arbeid/dagpenger/meldekort"
+        }
+
+        @Test
+        fun `kun innsendt - redirect DP_MELDEKORT`() {
+            coEvery { meldepliktConnector.hentMeldekortFraArena(ident) } returns listOf(arenaMeldekortInnsendt())
+
+            val response = runBlocking { service.hentMeldekortStatus(ident) }
+
+            response.harInnsendteMeldekort shouldBe true
+            response.meldekortTilUtfylling shouldBe emptyList()
+            response.redirectUrl shouldBe "/arbeid/dagpenger/meldekort"
+        }
+
+        @Test
+        fun `kun til utfylling - redirect DP_MELDEKORT`() {
+            coEvery { meldepliktConnector.hentMeldekortFraArena(ident) } returns listOf(arenaMeldekortTilUtfylling())
+
+            val response = runBlocking { service.hentMeldekortStatus(ident) }
+
+            response.harInnsendteMeldekort shouldBe false
+            response.meldekortTilUtfylling.size shouldBe 1
+            response.redirectUrl shouldBe "/arbeid/dagpenger/meldekort"
+        }
+
+        @Test
+        fun `ingen innsendt og ingen til utfylling - redirect FELLES_MELDEKORT`() {
+            coEvery { meldepliktConnector.hentMeldekortFraArena(ident) } returns
+                listOf(ArenaMeldekortResponse("Ferdig", idag.minusDays(14)))
+
+            val response = runBlocking { service.hentMeldekortStatus(ident) }
+
+            response.harInnsendteMeldekort shouldBe false
+            response.meldekortTilUtfylling shouldBe emptyList()
+            response.redirectUrl shouldBe "/felles-meldekort"
+        }
     }
 
-    @Test
-    fun `ingen innsendte men har meldekort til utfylling - redirect til meldekortflate`() {
-        coEvery { meldekortregisterConnector.hentMeldekort(ident) } returns
-            listOf(
-                meldekortTilUtfylling(kanSendesFra = idag, sisteFristForTrekk = idag.plusDays(7)),
-            )
+    @Nested
+    inner class Fallback {
+        @Test
+        fun `meldekortregister tom - henter fra Arena`() {
+            coEvery { meldekortregisterConnector.hentMeldekort(ident) } returns emptyList()
+            coEvery { meldepliktConnector.hentMeldekortFraArena(ident) } returns listOf(arenaMeldekortTilUtfylling())
 
-        val response = runBlocking { service.hentMeldekortStatus(ident) }
+            val response = runBlocking { service.hentMeldekortStatus(ident) }
 
-        response.harInnsendteMeldekort shouldBe false
-        response.meldekortTilUtfylling.size shouldBe 1
-        response.redirectUrl shouldBe "/arbeid/dagpenger/meldekort"
+            response.meldekortTilUtfylling.size shouldBe 1
+            response.redirectUrl shouldBe "/arbeid/dagpenger/meldekort"
+        }
+
+        @Test
+        fun `begge tomme - tom default respons`() {
+            coEvery { meldekortregisterConnector.hentMeldekort(ident) } returns emptyList()
+            coEvery { meldepliktConnector.hentMeldekortFraArena(ident) } returns emptyList()
+
+            val response = runBlocking { service.hentMeldekortStatus(ident) }
+
+            response.harInnsendteMeldekort shouldBe false
+            response.meldekortTilUtfylling shouldBe emptyList()
+            response.redirectUrl shouldBe ""
+        }
+
+        @Test
+        fun `meldekortregister krasjer - kaster exception`() {
+            coEvery { meldekortregisterConnector.hentMeldekort(ident) } throws RuntimeException("utilgjengelig")
+
+            shouldThrow<RuntimeException> {
+                runBlocking { service.hentMeldekortStatus(ident) }
+            }
+        }
+
+        @Test
+        fun `Arena krasjer - kaster exception`() {
+            coEvery { meldekortregisterConnector.hentMeldekort(ident) } returns emptyList()
+            coEvery { meldepliktConnector.hentMeldekortFraArena(ident) } throws RuntimeException("utilgjengelig")
+
+            shouldThrow<RuntimeException> {
+                runBlocking { service.hentMeldekortStatus(ident) }
+            }
+        }
     }
 
-    @Test
-    fun `ingen innsendte og ingen meldekort til utfylling - ingen redirect`() {
-        coEvery { meldekortregisterConnector.hentMeldekort(ident) } returns emptyList()
+    private fun innsendtMeldekort() = MeldekortResponse("Innsendt", idag.minusDays(14), idag.minusDays(7))
 
-        val response = runBlocking { service.hentMeldekortStatus(ident) }
+    private fun meldekortTilUtfylling() = MeldekortResponse("TilUtfylling", idag, idag.plusDays(7))
 
-        response.harInnsendteMeldekort shouldBe false
-        response.meldekortTilUtfylling shouldBe emptyList()
-        response.redirectUrl shouldBe ""
-    }
+    private fun arenaMeldekortInnsendt() = ArenaMeldekortResponse("Innsendt", idag.minusDays(14))
 
-    @Test
-    fun `returnerer tom default response når kall til meldekortregister feiler`() {
-        coEvery { meldekortregisterConnector.hentMeldekort(ident) } throws RuntimeException("Meldekortregister utilgjengelig")
-
-        val response = runBlocking { service.hentMeldekortStatus(ident) }
-
-        response.harInnsendteMeldekort shouldBe false
-        response.meldekortTilUtfylling shouldBe emptyList()
-        response.redirectUrl shouldBe ""
-    }
-
-    private fun innsendtMeldekort() =
-        MeldekortResponse(
-            status = "Innsendt",
-            kanSendesFra = idag.minusDays(14),
-            sisteFristForTrekk = idag.minusDays(7),
-        )
-
-    private fun meldekortTilUtfylling(
-        kanSendesFra: LocalDate,
-        sisteFristForTrekk: LocalDate,
-    ) = MeldekortResponse(
-        status = "TilUtfylling",
-        kanSendesFra = kanSendesFra,
-        sisteFristForTrekk = sisteFristForTrekk,
-    )
+    private fun arenaMeldekortTilUtfylling() = ArenaMeldekortResponse("TilUtfylling", idag)
 }

--- a/mediator/src/test/kotlin/no/nav/dagpenger/rapportering/personregister/mediator/service/MeldekortStatusServiceTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/rapportering/personregister/mediator/service/MeldekortStatusServiceTest.kt
@@ -1,0 +1,99 @@
+package no.nav.dagpenger.rapportering.personregister.mediator.service
+
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import no.nav.dagpenger.rapportering.personregister.mediator.connector.MeldekortResponse
+import no.nav.dagpenger.rapportering.personregister.mediator.connector.MeldekortregisterConnector
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+class MeldekortStatusServiceTest {
+    private val meldekortregisterConnector = mockk<MeldekortregisterConnector>()
+    private val service = MeldekortStatusService(meldekortregisterConnector)
+
+    private val ident = "12345678901"
+    private val idag = LocalDate.now()
+
+    @Test
+    fun `har innsendte og meldekort til utfylling - redirect til meldekortflate`() {
+        coEvery { meldekortregisterConnector.hentMeldekort(ident) } returns
+            listOf(
+                innsendtMeldekort(),
+                meldekortTilUtfylling(kanSendesFra = idag, sisteFristForTrekk = idag.plusDays(7)),
+            )
+
+        val response = runBlocking { service.hentStatus(ident) }
+
+        response.harInnsendteMeldekort shouldBe true
+        response.meldekortTilUtfylling.size shouldBe 1
+        response.redirectUrl shouldBe "/arbeid/dagpenger/meldekort"
+    }
+
+    @Test
+    fun `har innsendte men ingen meldekort til utfylling - redirect til meldekortflate`() {
+        coEvery { meldekortregisterConnector.hentMeldekort(ident) } returns
+            listOf(
+                innsendtMeldekort(),
+            )
+
+        val response = runBlocking { service.hentStatus(ident) }
+
+        response.harInnsendteMeldekort shouldBe true
+        response.meldekortTilUtfylling shouldBe emptyList()
+        response.redirectUrl shouldBe "/arbeid/dagpenger/meldekort"
+    }
+
+    @Test
+    fun `ingen innsendte men har meldekort til utfylling - redirect til meldekortflate`() {
+        coEvery { meldekortregisterConnector.hentMeldekort(ident) } returns
+            listOf(
+                meldekortTilUtfylling(kanSendesFra = idag, sisteFristForTrekk = idag.plusDays(7)),
+            )
+
+        val response = runBlocking { service.hentStatus(ident) }
+
+        response.harInnsendteMeldekort shouldBe false
+        response.meldekortTilUtfylling.size shouldBe 1
+        response.redirectUrl shouldBe "/arbeid/dagpenger/meldekort"
+    }
+
+    @Test
+    fun `ingen innsendte og ingen meldekort til utfylling - ingen redirect`() {
+        coEvery { meldekortregisterConnector.hentMeldekort(ident) } returns emptyList()
+
+        val response = runBlocking { service.hentStatus(ident) }
+
+        response.harInnsendteMeldekort shouldBe false
+        response.meldekortTilUtfylling shouldBe emptyList()
+        response.redirectUrl shouldBe ""
+    }
+
+    @Test
+    fun `returnerer tom default response når register feiler`() {
+        coEvery { meldekortregisterConnector.hentMeldekort(ident) } throws RuntimeException("Meldekortregister utilgjengelig")
+
+        val response = runBlocking { service.hentStatus(ident) }
+
+        response.harInnsendteMeldekort shouldBe false
+        response.meldekortTilUtfylling shouldBe emptyList()
+        response.redirectUrl shouldBe ""
+    }
+
+    private fun innsendtMeldekort() =
+        MeldekortResponse(
+            status = "Innsendt",
+            kanSendesFra = idag.minusDays(14),
+            sisteFristForTrekk = idag.minusDays(7),
+        )
+
+    private fun meldekortTilUtfylling(
+        kanSendesFra: LocalDate,
+        sisteFristForTrekk: LocalDate,
+    ) = MeldekortResponse(
+        status = "TilUtfylling",
+        kanSendesFra = kanSendesFra,
+        sisteFristForTrekk = sisteFristForTrekk,
+    )
+}

--- a/openapi/src/main/resources/personstatus-api.yaml
+++ b/openapi/src/main/resources/personstatus-api.yaml
@@ -194,21 +194,21 @@ components:
     MeldekortStatus:
         required:
             - harInnsendteMeldekort
-            - redirectUrl
             - meldekortTilUtfylling
+            - redirectUrl
         type: object
         properties:
             harInnsendteMeldekort:
                 type: boolean
                 description: Om personen har innsendte meldekort
-            redirectUrl:
-                type: string
-                format: string
-                description: URL til bruker sender meldekort
             meldekortTilUtfylling:
                 type: array
                 items:
                     $ref: '#/components/schemas/MeldekortTilUtfylling'
+            redirectUrl:
+                type: string
+                format: string
+                description: URL til bruker sender meldekort
     MeldekortTilUtfylling:
         type: object
         properties:

--- a/openapi/src/main/resources/personstatus-api.yaml
+++ b/openapi/src/main/resources/personstatus-api.yaml
@@ -116,8 +116,6 @@ paths:
             application/json:
               schema:
                   $ref: '#/components/schemas/MeldekortStatus'
-        404:
-          description: Not Found
       summary: Hent meldekortstatus for en person
       description: Hent meldekortstatus for en person basert på ident
       operationId: get-meldekortstatus

--- a/openapi/src/main/resources/personstatus-api.yaml
+++ b/openapi/src/main/resources/personstatus-api.yaml
@@ -121,15 +121,8 @@ paths:
       summary: Hent meldekortstatus for en person
       description: Hent meldekortstatus for en person basert på ident
       operationId: get-meldekortstatus
-      parameters:
-        - in: query
-          name: ident
-          schema:
-            type: string
-          required: true
-          description: ident til personen du vil hente meldekortstatus for
       security:
-        - azureAd: []
+        - tokenX: []
 
 components:
   schemas:

--- a/openapi/src/main/resources/personstatus-api.yaml
+++ b/openapi/src/main/resources/personstatus-api.yaml
@@ -10,6 +10,11 @@ servers:
     description: dev
   - url: https://dp-rapportering-personregister.intern.nav.no
     description: prod
+tags:
+    - name: PersonStatusApi
+      description: Endepunkter for personstatus
+    - name: MeldekortStatusApi
+      description: Endepunkter for meldekortstatus
 paths:
   /personstatus:
     get:
@@ -100,6 +105,31 @@ paths:
       security:
         - azureAd: []
 
+  /meldekort/status:
+    get:
+      tags:
+          - MeldekortStatusApi
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                  $ref: '#/components/schemas/MeldekortStatus'
+        404:
+          description: Not Found
+      summary: Hent meldekortstatus for en person
+      description: Hent meldekortstatus for en person basert på ident
+      operationId: get-meldekortstatus
+      parameters:
+        - in: query
+          name: ident
+          schema:
+            type: string
+          required: true
+          description: ident til personen du vil hente meldekortstatus for
+      security:
+        - azureAd: []
 
 components:
   schemas:
@@ -170,6 +200,35 @@ components:
             - Startet
             - Avsluttet
           description: Status for arbeidssøkerperioden
+    MeldekortStatus:
+        required:
+            - harInnsendteMeldekort
+            - redirectUrl
+            - meldekortTilUtfylling
+        type: object
+        properties:
+            harInnsendteMeldekort:
+                type: boolean
+                description: Om personen har innsendte meldekort
+            redirectUrl:
+                type: string
+                format: string
+                description: URL til bruker sender meldekort
+            meldekortTilUtfylling:
+                type: array
+                items:
+                    $ref: '#/components/schemas/MeldekortTilUtfylling'
+    MeldekortTilUtfylling:
+        type: object
+        properties:
+            kanSendesFra:
+                type: string
+                format: date-time
+                description: Tidligste dato for når meldekort kan sendes inn
+            fristForInnsending:
+                type: string
+                format: date-time
+                description: Frist for innsending av meldekort
     Problem:
       type: object
       description: Implementasjon av Problem Details for HTTP APIs [RFC 7807](https://datatracker.ietf.org/doc/html/rfc7807)


### PR DESCRIPTION
Nytt endepunkt som returnerer meldekortstatus som skal brukes i landingsside appen. Foreløpig henter den meldekort fra meldekortregister