### PR TITLE
Flytt ident-validering til egen String-extension

### DIFF
--- a/mediator/src/main/kotlin/no/nav/dagpenger/rapportering/personregister/mediator/api/BehandlingApi.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/rapportering/personregister/mediator/api/BehandlingApi.kt
@@ -11,6 +11,7 @@ import io.ktor.server.routing.post
 import io.ktor.server.routing.route
 import io.ktor.server.routing.routing
 import no.nav.dagpenger.rapportering.personregister.mediator.db.BehandlingRepository
+import no.nav.dagpenger.rapportering.personregister.mediator.utils.validerIdent
 
 private val logger = KotlinLogging.logger {}
 
@@ -22,9 +23,12 @@ internal fun Application.behandlingApi(behandlingRepository: BehandlingRepositor
                     logger.info { "POST /hentSisteSakId" }
                     val request = call.receive<IdentBody>()
 
-                    if (!request.ident.matches(Regex("[0-9]{11}"))) {
-                        logger.error { "Person-ident må ha 11 sifre" }
-                        throw BadRequestException("Person-ident må ha 11 sifre")
+                    try {
+                        request.ident.validerIdent()
+                    } catch (e: IllegalArgumentException) {
+                        val melding = "Validering av ident feilet: $e.message"
+                        logger.error { melding }
+                        throw BadRequestException(melding)
                     }
 
                     behandlingRepository

--- a/mediator/src/main/kotlin/no/nav/dagpenger/rapportering/personregister/mediator/api/PersonApi.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/rapportering/personregister/mediator/api/PersonApi.kt
@@ -13,6 +13,7 @@ import io.ktor.server.routing.route
 import io.ktor.server.routing.routing
 import no.nav.dagpenger.rapportering.personregister.api.models.ArbeidssokerperiodeResponse
 import no.nav.dagpenger.rapportering.personregister.mediator.service.PersonService
+import no.nav.dagpenger.rapportering.personregister.mediator.utils.validerIdent
 import java.net.URI
 import java.time.ZoneOffset
 
@@ -26,9 +27,12 @@ internal fun Application.personApi(personService: PersonService) {
                     logger.info { "POST /hentPersonId" }
                     val request = call.receive<IdentBody>()
 
-                    if (!request.ident.matches(Regex("[0-9]{11}"))) {
-                        logger.error { "Person-ident må ha 11 sifre" }
-                        throw BadRequestException("Person-ident må ha 11 sifre")
+                    try {
+                        request.ident.validerIdent()
+                    } catch (e: IllegalArgumentException) {
+                        val melding = "Validering av ident feilet: $e.message"
+                        logger.error { melding }
+                        throw BadRequestException(melding)
                     }
 
                     personService

--- a/mediator/src/main/kotlin/no/nav/dagpenger/rapportering/personregister/mediator/tjenester/BehandlingsresultatMottak.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/rapportering/personregister/mediator/tjenester/BehandlingsresultatMottak.kt
@@ -14,6 +14,7 @@ import no.nav.dagpenger.rapportering.personregister.mediator.FremtidigHendelseMe
 import no.nav.dagpenger.rapportering.personregister.mediator.PersonMediator
 import no.nav.dagpenger.rapportering.personregister.mediator.db.PersonRepository
 import no.nav.dagpenger.rapportering.personregister.mediator.metrikker.BehandlingsresultatMetrikker
+import no.nav.dagpenger.rapportering.personregister.mediator.utils.validerIdent
 import no.nav.dagpenger.rapportering.personregister.modell.hendelser.VedtakHendelse
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -69,9 +70,7 @@ class BehandlingsresultatMottak(
             try {
                 val ident = packet["ident"].asText()
 
-                if (!ident.matches(Regex("[0-9]{11}"))) {
-                    throw IllegalArgumentException("Person-ident må ha 11 sifre")
-                }
+                ident.validerIdent()
 
                 // Slett fremtidige VedtakHendelser
                 personRepository.slettFremtidigeVedtakHendelser(ident)

--- a/mediator/src/main/kotlin/no/nav/dagpenger/rapportering/personregister/mediator/tjenester/MeldesyklusErPassertMottak.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/rapportering/personregister/mediator/tjenester/MeldesyklusErPassertMottak.kt
@@ -10,6 +10,7 @@ import io.micrometer.core.instrument.MeterRegistry
 import io.opentelemetry.instrumentation.annotations.WithSpan
 import no.nav.dagpenger.rapportering.personregister.mediator.PersonMediator
 import no.nav.dagpenger.rapportering.personregister.mediator.metrikker.MeldesyklusErPassertMetrikker
+import no.nav.dagpenger.rapportering.personregister.mediator.utils.validerIdent
 import no.nav.dagpenger.rapportering.personregister.modell.hendelser.MeldesyklusErPassertHendelse
 import java.time.LocalDateTime
 
@@ -54,9 +55,7 @@ class MeldesyklusErPassertMottak(
             val ident = packet["ident"].asText()
             val referanseId = packet["referanseId"].asText()
 
-            if (!ident.matches(Regex("[0-9]{11}"))) {
-                throw IllegalArgumentException("Person-ident må ha 11 sifre")
-            }
+            ident.validerIdent()
 
             val meldesyklusErPassertHendelse =
                 MeldesyklusErPassertHendelse(

--- a/mediator/src/main/kotlin/no/nav/dagpenger/rapportering/personregister/mediator/utils/StringUtils.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/rapportering/personregister/mediator/utils/StringUtils.kt
@@ -1,0 +1,5 @@
+package no.nav.dagpenger.rapportering.personregister.mediator.utils
+
+private val ident11SifferRegex = Regex("[0-9]{11}")
+
+fun String.validerIdent() = require(this.matches(ident11SifferRegex)) { "Person-ident må ha 11 sifre" }

--- a/mediator/src/test/kotlin/no/nav/dagpenger/rapportering/personregister/mediator/utils/StringUtilsTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/rapportering/personregister/mediator/utils/StringUtilsTest.kt
@@ -1,0 +1,25 @@
+package no.nav.dagpenger.rapportering.personregister.mediator.utils
+
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+
+class StringUtilsTest {
+    @Test
+    fun `validerIdent kaster ikke exception hvis ident inneholder 11 siffer`() {
+        shouldNotThrowAny { "12345678901".validerIdent() }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["", "a", "1", "QWERTYUIOPÅ", "123456789012", "Q1W2E3R4T5Y'"])
+    fun `validerIdent kaster exception hvis ident inneholder ugyldige kombinasjoner av tall, bokstaver og lengden på ident`(
+        ident: String,
+    ) {
+        val exception = shouldThrow<IllegalArgumentException> { ident.validerIdent() }
+
+        exception.message shouldBe "Person-ident må ha 11 sifre"
+    }
+}


### PR DESCRIPTION
Jeg begynte så smått på https://trello.com/c/Yv6thurl/436-les-melding-om-bekreftelse-svar-p%C3%A5-sp%C3%B8rsm%C3%A5l-5-fra-rr-og-send-bekreftelse-melding-til-arbeidss%C3%B8kerregisteret før Abdi tok over den, og da gjorde jeg denne refaktoreringen. Tenkte det var like greit å bare lage en PR på det.