### PR TITLE
Fjern Docker og NPM

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -18,21 +18,3 @@ updates:
       timezone: "Europe/Oslo"
     cooldown:
       default-days: 7
-  # Maintain dependencies for docker
-  - package-ecosystem: "docker"
-    directory: "/"
-    schedule:
-      interval: "daily"
-      time: "10:05"
-      timezone: "Europe/Oslo"
-    cooldown:
-      default-days: 7
-  # Maintain dependencies for npm
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "daily"
-      time: "10:05"
-      timezone: "Europe/Oslo"
-    cooldown:
-      default-days: 7


### PR DESCRIPTION
* Docker-sjekk gjøres av Digestabot.
* Denne appen har ikke noe NPM-greier heller.