### PR TITLE
feat: avslutt meldekortproduksjon ved behandlingsresultat med tilOgMe…

### DIFF
--- a/mediator/src/test/kotlin/no/nav/dagpenger/rapportering/personregister/mediator/tjenester/BehandlingsresultatMottakTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/rapportering/personregister/mediator/tjenester/BehandlingsresultatMottakTest.kt
@@ -156,6 +156,55 @@ class BehandlingsresultatMottakTest {
     }
 
     @Test
+    fun `innvilget rettighetsperiode med tilOgMed tilbake i tid rutes til personMediator med utfall true`() {
+        val ident = "12345678903"
+        val behandlingId = UUIDv7.newUuid().toString()
+        val søknadId = UUIDv7.newUuid().toString()
+        val fraOgMed = LocalDate.now().minusDays(40)
+        val tilOgMed = LocalDate.now().minusDays(10)
+
+        val hendelser = mutableListOf<VedtakHendelse>()
+        every { personMediator.behandle(capture(hendelser), 1) } just runs
+
+        val behandlingsresultat =
+            """
+            {
+              "@event_name": "behandlingsresultat",
+              "behandlingId": "$behandlingId",
+              "behandletHendelse": {
+                "datatype": "string",
+                "id": "$søknadId",
+                "type": "Søknad"
+              },
+              "basertPå": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+              "automatisk": true,
+              "ident": "$ident",
+              "opplysninger": [ ],
+              "rettighetsperioder": [
+                {
+                  "fraOgMed": "$fraOgMed",
+                  "tilOgMed": "$tilOgMed",
+                  "harRett": true,
+                  "opprinnelse": "Ny"
+                }
+              ]
+            }
+            """.trimIndent()
+
+        testRapid.sendTestMessage(behandlingsresultat)
+
+        verify { personRepository.slettFremtidigeVedtakHendelser(eq(ident)) }
+        verify(exactly = 0) { fremtidigHendelseMediator.behandle(any()) }
+
+        hendelser.size shouldBe 1
+        hendelser[0].ident shouldBe ident
+        hendelser[0].startDato shouldBe fraOgMed.atStartOfDay()
+        hendelser[0].sluttDato shouldBe tilOgMed.atStartOfDay()
+        hendelser[0].referanseId shouldBe "$behandlingId-0"
+        hendelser[0].utfall shouldBe true
+    }
+
+    @Test
     fun `onPacket kaster exception og inkrementerer metrikk hvis behandling av melding feiler`() {
         val metrikkCount = behandlingsresultatMetrikker.behandlingsresultatFeilet.count()
         every { personMediator.behandle(any<VedtakHendelse>()) } throws RuntimeException("kaboom")

--- a/modell/src/main/kotlin/no/nav/dagpenger/rapportering/personregister/modell/hendelser/VedtakHendelse.kt
+++ b/modell/src/main/kotlin/no/nav/dagpenger/rapportering/personregister/modell/hendelser/VedtakHendelse.kt
@@ -10,6 +10,7 @@ import no.nav.dagpenger.rapportering.personregister.modell.sendOvertakelsesmeldi
 import no.nav.dagpenger.rapportering.personregister.modell.sendStartMeldingTilMeldekortregister
 import no.nav.dagpenger.rapportering.personregister.modell.sendStoppMeldingTilMeldekortregister
 import no.nav.dagpenger.rapportering.personregister.modell.vurderNyStatus
+import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalDateTime.now
 
@@ -26,20 +27,44 @@ data class VedtakHendelse(
     override fun behandle(person: Person) {
         person.hendelser.add(this)
 
-        // Starter eller stopper meldekortproduksjon basert på vedtakets utfall
-        if (utfall) {
-            val skalMigreres = person.ansvarligSystem != AnsvarligSystem.DP
-            person.setAnsvarligSystem(AnsvarligSystem.DP)
-
-            person.setHarRettTilDp(true)
-            person.sendStartMeldingTilMeldekortregister(fraOgMed = startDato, tilOgMed = sluttDato, skalMigreres = skalMigreres)
+        if (skalStarteDagpenger) {
+            startDagpenger(person)
         } else {
-            person.setHarRettTilDp(false)
-            if (person.ansvarligSystem == AnsvarligSystem.DP) {
-                person.sendStoppMeldingTilMeldekortregister(fraOgMed = startDato, tilOgMed = sluttDato)
-            }
+            avsluttDagpenger(person)
         }
 
+        oppdaterStatus(person)
+    }
+
+    private val skalStarteDagpenger: Boolean
+        get() = utfall && !sluttDatoErPassert
+
+    private val erInnvilgetTilbakeITid: Boolean
+        get() = utfall && sluttDatoErPassert
+
+    private val sluttDatoErPassert: Boolean
+        get() = sluttDato?.toLocalDate()?.isBefore(LocalDate.now()) ?: false
+
+    private fun startDagpenger(person: Person) {
+        val skalMigreres = person.ansvarligSystem != AnsvarligSystem.DP
+        person.setAnsvarligSystem(AnsvarligSystem.DP)
+        person.setHarRettTilDp(true)
+        person.sendStartMeldingTilMeldekortregister(fraOgMed = startDato, tilOgMed = sluttDato, skalMigreres = skalMigreres)
+    }
+
+    private fun avsluttDagpenger(person: Person) {
+        person.setHarRettTilDp(false)
+
+        if (erInnvilgetTilbakeITid && person.ansvarligSystem != AnsvarligSystem.DP) {
+            person.setAnsvarligSystem(AnsvarligSystem.DP)
+        }
+
+        if (person.ansvarligSystem == AnsvarligSystem.DP) person.stoppMeldekortproduksjon()
+    }
+
+    private fun Person.stoppMeldekortproduksjon() = sendStoppMeldingTilMeldekortregister(fraOgMed = startDato, tilOgMed = sluttDato)
+
+    private fun oppdaterStatus(person: Person) {
         person
             .vurderNyStatus()
             .takeIf { it != person.status }

--- a/modell/src/test/kotlin/no/nav/dagpenger/rapportering/personregister/modell/PersonTest.kt
+++ b/modell/src/test/kotlin/no/nav/dagpenger/rapportering/personregister/modell/PersonTest.kt
@@ -96,6 +96,59 @@ class PersonTest {
                 this.status shouldBe IKKE_DAGPENGERBRUKER
                 arbeidssøkerperiodeObserver skalHaFrasagtAnsvaretFor this
             }
+
+        @Test
+        fun `innvilget vedtak med tilOgMed tilbake i tid avslutter meldekortproduksjon for dagpengerbruker`() =
+            arbeidssøker(overtattBekreftelse = true) {
+                hendelser.add(søknadHendelse(referanseId = "456"))
+                behandle(vedtakHendelse(utfall = true))
+                status shouldBe DAGPENGERBRUKER
+
+                val innvilgetTilbakeITid = vedtakHendelse(dato = tidligere, utfall = true, sluttDato = tidligere)
+                behandle(innvilgetTilbakeITid)
+
+                ansvarligSystem shouldBe AnsvarligSystem.DP
+                this skalHaSendtStoppMeldingFor Periode(innvilgetTilbakeITid.startDato, innvilgetTilbakeITid.sluttDato)
+                this skalIkkeHaSendtStartMeldingFor Periode(innvilgetTilbakeITid.startDato, innvilgetTilbakeITid.sluttDato)
+                status shouldBe IKKE_DAGPENGERBRUKER
+                arbeidssøkerperiodeObserver skalHaFrasagtAnsvaretFor this
+            }
+
+        @Test
+        fun `innvilget vedtak med tilOgMed tilbake i tid starter ikke meldekortproduksjon for ny bruker`() =
+            arbeidssøker {
+                hendelser.add(søknadHendelse(referanseId = "456"))
+
+                val innvilgetTilbakeITid = vedtakHendelse(dato = tidligere, utfall = true, sluttDato = tidligere)
+                behandle(innvilgetTilbakeITid)
+
+                ansvarligSystem shouldBe AnsvarligSystem.DP
+                this skalHaSendtStoppMeldingFor Periode(innvilgetTilbakeITid.startDato, innvilgetTilbakeITid.sluttDato)
+                this skalIkkeHaSendtStartMeldingFor Periode(innvilgetTilbakeITid.startDato, innvilgetTilbakeITid.sluttDato)
+                status shouldBe IKKE_DAGPENGERBRUKER
+            }
+
+        @Test
+        fun `innvilget vedtak med tilOgMed i dag starter meldekortproduksjon`() =
+            arbeidssøker {
+                val vedtakHendelse = vedtakHendelse(utfall = true, sluttDato = nå)
+                behandle(vedtakHendelse)
+
+                ansvarligSystem shouldBe AnsvarligSystem.DP
+                this skalHaSendtStartMeldingFor Periode(vedtakHendelse.startDato, vedtakHendelse.sluttDato)
+                status shouldBe DAGPENGERBRUKER
+            }
+
+        @Test
+        fun `innvilget vedtak uten tilOgMed starter meldekortproduksjon`() =
+            arbeidssøker {
+                val vedtakHendelse = vedtakHendelse(utfall = true, sluttDato = null)
+                behandle(vedtakHendelse)
+
+                ansvarligSystem shouldBe AnsvarligSystem.DP
+                this skalHaSendtStartMeldingFor Periode(vedtakHendelse.startDato, null)
+                status shouldBe DAGPENGERBRUKER
+            }
     }
 
     @Nested
@@ -265,7 +318,8 @@ class PersonTest {
         dato: LocalDateTime = nå,
         referanseId: String = "123",
         utfall: Boolean = true,
-    ) = VedtakHendelse(ident, dato, dato, referanseId, dato.plusDays(10), utfall)
+        sluttDato: LocalDateTime? = dato.plusDays(10),
+    ) = VedtakHendelse(ident, dato, dato, referanseId, sluttDato, utfall)
 
     private fun meldepliktHendelse(
         dato: LocalDateTime = nå,
@@ -303,6 +357,10 @@ infix fun PersonObserver.skalHaFrasagtSegAnsvaretMedFristBruttFor(person: Person
 
 infix fun Person.skalHaSendtStartMeldingFor(periode: Periode) {
     verify(exactly = 1) { sendStartMeldingTilMeldekortregister(periode.startDato, periode.sluttDato, any()) }
+}
+
+infix fun Person.skalIkkeHaSendtStartMeldingFor(periode: Periode) {
+    verify(exactly = 0) { sendStartMeldingTilMeldekortregister(periode.startDato, periode.sluttDato, any()) }
 }
 
 infix fun Person.skalHaSendtStoppMeldingFor(periode: Periode) {


### PR DESCRIPTION
…d tilbake i tid

Et innvilget vedtak (harRett=true) med tilOgMed-dato i fortid skal ikke starte meldekortproduksjon, men avslutte den umiddelbart. tilOgMed er inklusiv, så perioden regnes som passert først dagen etter sluttdato.

Endringer i VedtakHendelse:
- Skiller mellom å starte og avslutte dagpenger basert på om sluttdato er passert (skalStarteDagpenger / erInnvilgetTilbakeITid).
- Ved innvilgelse tilbake i tid overtar DP ansvaret (hvis ikke allerede DP) og sender stopp-melding til meldekortregisteret.
- Frasigelse til arbeidssøkerregisteret håndteres via eksisterende statusovergang til IKKE_DAGPENGERBRUKER.

Tester:
- Dekker innvilgelse tilbake i tid for både ny bruker og eksisterende dagpengerbruker, samt grensetilfeller (tilOgMed = i dag, uten tilOgMed).
- BehandlingsresultatMottak: verifiserer ruting og videreføring av sluttDato.